### PR TITLE
Fix hang when closing adb reverse tunnel

### DIFF
--- a/src/symmetrical_doodle/adb_tunnel.py
+++ b/src/symmetrical_doodle/adb_tunnel.py
@@ -94,7 +94,6 @@ class Tunnel:
                 f"localabstract:{self.device_socket_name}"
             )
             self.server.close()
-            await self.server.wait_closed()
             await self.close_connections()
 
     async def close_connections(self):


### PR DESCRIPTION
According to https://www.github.com/python/cpython/pull/111336, `asyncio.Server.wait_closed` is intended to wait for: the server is closed and there are no more active connections.

The documentation about `asyncio.Server` before Python 3.11 does not mention this behavior (for until are no more active connections).

The server for adb reverse tunnel should not wait for connections to finish (don't care about the connections that are already taken away) when closing the adb reverse tunnel, so do not call `wait_closed`.

Other related issues:
https://www.github.com/python/cpython/issues/104344
https://www.github.com/python/cpython/issues/79033